### PR TITLE
Add controller pinging

### DIFF
--- a/controller_fw/controller_fw.ino
+++ b/controller_fw/controller_fw.ino
@@ -24,7 +24,7 @@ void setup() {
 
   Serial.begin(9600);
   inputString.reserve(200);
-  Serial.println("Controller initialized");
+  //Serial.println("Controller initialized");
 
 }
 

--- a/python_lib/turret.py
+++ b/python_lib/turret.py
@@ -4,7 +4,11 @@ from time import sleep
 
 class MyTurret:
 	"""Wifi turret class"""
-	def __init__(self,tty='/dev/ttyUSB0',timeout=10,invertx=False,inverty=False,step_deg=1,step_sec=0.05):
+	def __init__(self, tty='/dev/ttyUSB0', timeout=10, 
+			invertx=False, inverty=False, 
+			step_deg=1, step_sec=0.05, 
+			debug=1):
+		self.debug = debug
 		self.port=serial.Serial(port=tty, 
 				baudrate=9600,
     				parity=serial.PARITY_ODD,
@@ -13,18 +17,42 @@ class MyTurret:
 				timeout=timeout)
 		self.port.open()
 		#self.port.write("test\n")
-		test=self.port.readline() #wait for initalizing
-		self.port.flushInput()
+		#test=self.port.readline() #wait for initalizing
+		#self.port.flushInput()
 		self.inverty=inverty
 		self.invertx=invertx
 		self.step_deg = step_deg
 		self.step_sec = step_sec
+		# Set ping timeout as 1/5 of main timeout, 
+		# but not less than 1 sec.
+		# By default, 10/5 = 2 sec.
+		# Float timeout values is allowed by pyserial.
+		self.ping_timeout = max(timeout/5.0, 1)
+		# Wait for initializing
+		while (not self.ping()):
+			sleep(0.5)
+
 
 	def __del__(self):
 		self.finish()
 
 	def finish(self):
 		self.port.close()
+	
+	def ping(self):
+		old_timeout = self.port.timeout
+		self.port.timeout = self.ping_timeout
+		if (self.debug):
+			print('Pinging...')
+		self.port.write('test\n')
+		out = self.port.readline().rstrip()
+		if (self.debug):
+			print('Got answer: "{:s}"'.format(out) \
+					if out else 'Timeout!')
+		self.port.timeout = old_timeout
+		if (out == 'OK'):
+			return True
+		return False
 
 	def invert(self,var):
 		return (180 - var)
@@ -77,8 +105,8 @@ class MyTurret:
 			raise ZeroDivisionError("Wat da fuck?")
 		# Guarantee that last value will be newval
 		for it in range(oldval + step, newval, step) + [newval]:
-			# Debug 
-			print("Set {:1s}={:3d}".format(coord, it))
+			if (self.debug):
+				print("Set {:1s}={:3d}".format(coord, it))
 			self.port.write('s{:s}{:d}\n'.format(coord, it))
 			sleep(self.step_sec)
 	


### PR DESCRIPTION
Get rid of non-requested-answer 'Controller initialized'.
Speed up initialization, and possibly fix bug from README.md.

Also, add parameter for easy switch debug output.

After pressing reset button on controller, and immediately initializing
turret object, I got

```
>>> tur = turret.MyTurret()
Pinging...
Timeout!
Pinging...
Got answer: "OK"
```
